### PR TITLE
Add GitHub Actions workflow for .NET code metrics

### DIFF
--- a/.github/workflows/code-metrics.yml
+++ b/.github/workflows/code-metrics.yml
@@ -1,0 +1,52 @@
+---
+
+name: '.NET code metrics'
+
+on:
+  push:
+    branches: [ "main", "*" ]
+    paths:
+      - '!./CODE_METRICS.md' # ignore this file
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '!./CODE_METRICS.md' # ignore this file
+
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'The reason for running the workflow'
+        required: true
+        default: 'Manual run'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Print manual run reason'
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo 'Reason: ${{ github.event.inputs.reason }}'
+      - name: .NET code metrics
+        id: dotnet-code-metrics
+        uses: dotnet/samples/github-actions/DotNet.GitHubAction@main
+        env:
+          GREETINGS: 'Hello, .NET developers!' # ${{ secrets.GITHUB_TOKEN }}
+        with:
+          owner: ${{ github.repository_owner }}
+          name: ${{ github.repository }}
+          branch: ${{ github.ref }}
+          dir: ${{ './' }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7.0.6
+        if: ${{ steps.dotnet-code-metrics.outputs.updated-metrics }} == 'true'
+        with:
+          title: '${{ steps.dotnet-code-metrics.outputs.summary-title }}'
+          body: '${{ steps.dotnet-code-metrics.outputs.summary-details }}'
+          commit-message: '.NET code metrics, automated pull request.'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,69 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+---
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main", "*" ]
+
+    paths:
+      - '**.cs'
+      - '**.csproj'
+
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+    paths:
+      - '**.cs'
+      - '**.csproj'
+
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'The reason for running the workflow'
+        required: true
+        default: 'Manual run'
+
+  schedule:
+    - cron: '31 0 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'html', 'razor' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,12 +5,12 @@ name: .NET Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "*" ]
     paths:
       - 'src/**'
       - 'tests/**'
   pull_request:
-    branches: [ "*" ]
+    branches: [ "main" ]
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
This workflow calculates .NET code metrics on push and pull request events, excluding specific files. It also supports manual triggers with optional reasons and creates automated pull requests if metrics are updated.
This pull request introduces new GitHub Actions workflows for code metrics and CodeQL analysis, and modifies the existing .NET build workflow to align branch specifications. The key changes are as follows:

### New Workflows

* **.NET Code Metrics Workflow**: Added a new workflow to generate .NET code metrics on pushes and pull requests to the main branch, with the ability to manually trigger the workflow. This workflow uses the `dotnet/samples/github-actions/DotNet.GitHubAction` and `peter-evans/create-pull-request` actions. (`.github/workflows/code-metrics.yml`)

* **CodeQL Analysis Workflow**: Added a new workflow to perform CodeQL analysis on C# files, triggered by pushes, pull requests to the main branch, and on a scheduled basis. This workflow uses the `github/codeql-action/init`, `github/codeql-action/autobuild`, and `github/codeql-action/analyze` actions. (`.github/workflows/codeql-analysis.yml`)

### Workflow Modifications

* **.NET Build Workflow**: Modified the branch specifications for the .NET build workflow to include all branches on push events and restrict to the main branch on pull request events. (`.github/workflows/dotnet.yml`)