### PR TITLE
Fix fallback approach for author.UserName assignments**

### DIFF
--- a/src/BlazingBlog.Application/Articles/GetArticleById/GetArticleByIdQueryHandler.cs
+++ b/src/BlazingBlog.Application/Articles/GetArticleById/GetArticleByIdQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetArticleByIdQueryHandler : IQueryHandler<GetArticleByIdQuery, Art
 		else
 		{
 
-			articleResponse.UserName = author?.UserName ?? "Unknown";
+			articleResponse.UserName = author.UserName!;
 			articleResponse.UserId = article.UserId;
 			articleResponse.CanEdit = await _userService.CurrentUserCanEditArticlesAsync(article.Id);
 

--- a/src/BlazingBlog.Application/Articles/GetArticleByIdForEditing/GetArticleByIdForEditingQueryHandler.cs
+++ b/src/BlazingBlog.Application/Articles/GetArticleByIdForEditing/GetArticleByIdForEditingQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetArticleByIdForEditingQueryHandler : IQueryHandler<GetArticleById
 		else
 		{
 
-			articleResponse.UserName = author?.UserName ?? "Unknown";
+			articleResponse.UserName = author?.UserName!;
 			articleResponse.UserId = article.UserId;
 			articleResponse.CanEdit = await _userService.CurrentUserCanEditArticlesAsync(article.Id);
 

--- a/src/BlazingBlog.Application/Articles/GetArticles/GetArticleQueryHandler.cs
+++ b/src/BlazingBlog.Application/Articles/GetArticles/GetArticleQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetArticleQueryHandler : IQueryHandler<GetArticleQuery, List<Articl
 			else
 			{
 				
-				articleResponse.UserName = author?.UserName ?? "Unknown";
+				articleResponse.UserName = author?.UserName!;
 
 				articleResponse.UserId = article.UserId;
 


### PR DESCRIPTION
### Description
This pull request replaces the null-coalescing fallback ("Unknown") with a non-null assertion for `author.UserName` in various query handlers. This change ensures that default values are not assigned unnecessarily, maintaining consistency when the `author` object is presumed non-null.

### Checklist
- [x] Code changes are covered with tests
- [x] Documentation updated if needed
- [x] All checks pass on CI