### PR TITLE
Fix unnecessary null-coalescing in UserName assignment

### DIFF
--- a/src/BlazingBlog.Application/Articles/GetArticleByIdForEditing/GetArticleByIdForEditingQueryHandler.cs
+++ b/src/BlazingBlog.Application/Articles/GetArticleByIdForEditing/GetArticleByIdForEditingQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetArticleByIdForEditingQueryHandler : IQueryHandler<GetArticleById
 		else
 		{
 
-			articleResponse.UserName = author?.UserName!;
+			articleResponse.UserName = author.UserName!;
 			articleResponse.UserId = article.UserId;
 			articleResponse.CanEdit = await _userService.CurrentUserCanEditArticlesAsync(article.Id);
 

--- a/src/BlazingBlog.Application/Articles/GetArticles/GetArticleQueryHandler.cs
+++ b/src/BlazingBlog.Application/Articles/GetArticles/GetArticleQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetArticleQueryHandler : IQueryHandler<GetArticleQuery, List<Articl
 			else
 			{
 				
-				articleResponse.UserName = author?.UserName!;
+				articleResponse.UserName = author.UserName!;
 
 				articleResponse.UserId = article.UserId;
 


### PR DESCRIPTION
### Description

This pull request fixes a null-coalescing operator issue in the author `UserName` assignment. The redundant operator is removed, ensuring cleaner and more predictable code functionality.